### PR TITLE
added support for SNS notification reports

### DIFF
--- a/AWSCloudTrail/cloudtraillake-orchestrator/config.ts
+++ b/AWSCloudTrail/cloudtraillake-orchestrator/config.ts
@@ -1,5 +1,9 @@
 export const Config = {
     // The ARN of the CloudTrail Lake Event Data Store
     // Permission will be given to the Lambda function to query this event data store
-    CloudtraillakeEventDataStoreArn: "PROVIDE THIS"
+    // must start with arn:aws:cloudtrail:
+    CloudtraillakeEventDataStoreArn: "PROVIDE THIS",
+    // The email address which will recieve notifications from SNS for any service limit quota limits that are requested
+    // Note: you will need to check your inbox after deploying the CDK and confirm the SNS subscription
+    NotifyEmailAddress: "PROVIDE THIS"
 };

--- a/AWSCloudTrail/cloudtraillake-orchestrator/step-functions/state-machine.json
+++ b/AWSCloudTrail/cloudtraillake-orchestrator/step-functions/state-machine.json
@@ -9,7 +9,7 @@
         "FunctionName": "PLACEHOLDER",
         "Payload": {
           "EventDataStore": "PLACEHOLDER",
-          "QueryStatement": "SELECT json_extract_scalar(element_at(responseElements, 'requestedQuota'), '$.id') as requestId FROM {m[EventDataStore]} WHERE eventSource='servicequotas.amazonaws.com' and eventname = 'RequestServiceQuotaIncrease'",
+          "QueryStatement": "SELECT json_extract_scalar(element_at(responseElements, 'requestedQuota'), '$.id') as requestId, awsRegion, recipientAccountId FROM {m[EventDataStore]} WHERE eventSource='servicequotas.amazonaws.com' and eventname = 'RequestServiceQuotaIncrease'",
           "QueryFormatParams": {
             "EventDataStore": "PLACEHOLDER"
           }
@@ -42,7 +42,7 @@
               "FunctionName": "PLACEHOLDER",
               "Payload": {
                 "EventDataStore": "PLACEHOLDER",
-                "QueryStatement": "SELECT serviceEventDetails FROM {m[EventDataStore]} WHERE eventSource='servicequotas.amazonaws.com' and eventname = 'UpdateServiceQuotaIncreaseRequestStatus' and element_at(serviceEventDetails, 'requestId') = '{m[RequestId]}'",
+                "QueryStatement": "SELECT recipientAccountId, awsRegion, serviceEventDetails FROM {m[EventDataStore]} WHERE eventSource='servicequotas.amazonaws.com' and eventname = 'UpdateServiceQuotaIncreaseRequestStatus' and element_at(serviceEventDetails, 'requestId') = '{m[RequestId]}'",
                 "QueryFormatParams": {
                   "EventDataStore": "PLACEHOLDER",
                   "RequestId.$": "$[0].requestId"
@@ -64,7 +64,14 @@
             "Next": "Send_Report"
           },
           "Send_Report": {
-            "Type": "Pass",
+            "Type": "Task",
+            "Resource": "arn:aws:states:::sns:publish",
+            "Parameters": {
+              "Message": {
+                "ServiceLimitIncreaseStatus.$": "$.Payload.body[0]"
+              },
+              "TopicArn": "PLACEHOLDER"
+            },
             "End": true
           }
         }


### PR DESCRIPTION
Added support for sending the status of each service limit increase to an SNS topic with an email subscriber. 
Also include the region and the account number.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
