### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/AWSConfig/AWS-Config-OPA/cfn_templates/lambda_backend/opa-lambda.yaml
+++ b/AWSConfig/AWS-Config-OPA/cfn_templates/lambda_backend/opa-lambda.yaml
@@ -96,7 +96,7 @@ Resources:
     Properties:
       CompatibleRuntimes:
         - python3.6
-        - python3.7
+        - python3.10
         - python3.8
       Content:
         S3Bucket: !Ref AssetsBucket

--- a/AWSConfig/CloudEndureCheckReplication/cf-template.json
+++ b/AWSConfig/CloudEndureCheckReplication/cf-template.json
@@ -87,7 +87,7 @@
                 "Timeout": {
                     "Ref": "Timeout"
                 },
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Description": "Create a new AWS lambda function for rule code"
             },
             "DependsOn": "LambdaRole"

--- a/AWSLicenseManager/TrackLicenses_MultiRegion/LM-MULTIREGION_LicenseTracking.yml
+++ b/AWSLicenseManager/TrackLicenses_MultiRegion/LM-MULTIREGION_LicenseTracking.yml
@@ -58,7 +58,7 @@ Resources:
   LicenseTrackingLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      Runtime: python3.7
+      Runtime: python3.10
       Role: !GetAtt LambdaRole.Arn
       Handler: index.handler
       Timeout: 120

--- a/AWSSystemsManager/CentralizedPatchManagement/opsmgmt-central-account.yaml
+++ b/AWSSystemsManager/CentralizedPatchManagement/opsmgmt-central-account.yaml
@@ -370,7 +370,7 @@ Resources:
       FunctionName: SSM-DeleteGlueTableColumnFunction
       Description:
         Deletes the 'resourcetype' Glue table that causes an issue when loading partitions in Athena
-      Runtime: python3.7
+      Runtime: python3.10
       Handler: index.lambda_handler
       MemorySize: 128
       Timeout: 600

--- a/AWSSystemsManager/CentralizedPatchManagement/opsmgmt-operations-central-account.yaml
+++ b/AWSSystemsManager/CentralizedPatchManagement/opsmgmt-operations-central-account.yaml
@@ -257,7 +257,7 @@ Resources:
       FunctionName: MultiAccountPatching
       Handler: index.handler
       Role: !GetAtt AWSLambdaSSMMultiAccountRole.Arn 
-      Runtime: python3.7
+      Runtime: python3.10
       
   #-------------------------------------------------
   # Automation document to run AWS-RunPatchBaseline on target resources


### PR DESCRIPTION
CloudFormation templates in aws-management-and-governance-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.